### PR TITLE
Force exit of all user processes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,10 +45,10 @@ target_link_options(gpu PRIVATE
     "-static-libstdc++" "-static-libgcc"
 )
 
-add_executable(hide_devices
-    src/hide_devices.cpp
+add_executable(gpu_container
+    src/gpu_container.cpp
 )
-target_link_options(hide_devices PRIVATE
+target_link_options(gpu_container PRIVATE
     "-static-libstdc++" "-static-libgcc"
 )
 
@@ -58,7 +58,7 @@ install(TARGETS gpu
 install(TARGETS gpu_server
     RUNTIME DESTINATION sbin
 )
-install(TARGETS hide_devices
+install(TARGETS gpu_container
     RUNTIME DESTINATION lib/gpu/
     PERMISSIONS OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE SETUID
 )

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -342,10 +342,10 @@ int main(int argc, char** argv)
         }
 
         bool doHideDevices = !vm.count("no-isolation");
-        auto hide_devices = installPath / "lib/gpu/hide_devices";
-        if(!std::filesystem::exists(hide_devices))
+        auto gpu_container = installPath / "lib/gpu/gpu_container";
+        if(!std::filesystem::exists(gpu_container))
         {
-            fprintf(stderr, "Could not find hide_devices helper (expected it at %s)\n", hide_devices.c_str());
+            fprintf(stderr, "Could not find gpu_container helper (expected it at %s)\n", gpu_container.c_str());
             return 1;
         }
 
@@ -407,8 +407,8 @@ int main(int argc, char** argv)
             if(doHideDevices)
             {
                 // argv[0]
-                executable = hide_devices;
-                args.push_back(strdup("hide_devices"));
+                executable = gpu_container;
+                args.push_back(strdup("gpu_container"));
 
                 auto deviceRegex = std::regex{"nvidia(\\d+)"};
                 for(auto& entry : std::filesystem::directory_iterator{"/dev"})

--- a/src/gpu_container.cpp
+++ b/src/gpu_container.cpp
@@ -1,4 +1,6 @@
-// Hide
+// Containerize the child process so that it only sees the specified GPUs
+// Author: Max Schwarz <max.schwarz@ais.uni-bonn.de>
+
 #include <sched.h>
 #include <stdio.h>
 
@@ -14,7 +16,7 @@
 
 void usage()
 {
-    fprintf(stderr, "Usage: hide_devices <device file names...> -- <command> [args]\n");
+    fprintf(stderr, "Usage: gpu_container <device file names...> -- <command> [args]\n");
     fprintf(stderr, "\n");
     fprintf(stderr, "This helper will hide the mentioned device file names from the command to be executed.\n");
 }


### PR DESCRIPTION
This uses Linux PID namespaces to ensure that all descendant processes that are created by the user application are cleaned up.

We also rename the hide_devices utility to gpu_container, since that more accurately describes its purpose.